### PR TITLE
add CI for pull requests

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -1,7 +1,4 @@
-# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
-
-name: Node.js CI
+name: Pull requests CI
 
 on:
   pull_request:
@@ -15,7 +12,6 @@ jobs:
     strategy:
       matrix:
         node-version: [22.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
This PR adds a workflow to run the following per pull requerst targetting main:
- linter
- build

We didn't add type check yet as it requires for at least one file in the project to be a typescript file. Conversion of typescript files is not covered in this MR.