### PR TITLE
ci: rename workflow job [noissue]

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -5,7 +5,8 @@ on:
     branches: [ "main" ]
 
 jobs:
-  build:
+  test-build:
+    name: Test and build
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
This MR adds a name to a PR workflow job so it can be detected by github status checks in settings