### PR TITLE
Feat: add undo and redo functionality [#16]

### DIFF
--- a/src/components/historyControls.tsx
+++ b/src/components/historyControls.tsx
@@ -1,0 +1,76 @@
+import type { CardsMap } from "./app.types";
+
+interface HistoryControlsProps {
+  boardHistory: CardsMap[];
+  historyIdx: number;
+  handlers: {
+    updateBoardData: (newCardsMap: CardsMap, rewriteHistory: boolean) => void;
+    setHistoryIdx: (newHistoryIdx: number) => void;
+  };
+}
+
+export function HistoryContros({
+  boardHistory,
+  historyIdx,
+  handlers,
+}: HistoryControlsProps) {
+  const { updateBoardData, setHistoryIdx } = handlers;
+
+  /**
+   * Brings back the state of the board to a previous state in history
+   *
+   * @returns
+   */
+  function undoBoardState() {
+    if (historyIdx <= 0) {
+      console.error(
+        "Undo action can't be done. There's no previous board data stored"
+      );
+      return;
+    }
+
+    const newHistoryIdx = historyIdx - 1;
+    const newCardsMap = structuredClone(boardHistory[newHistoryIdx]);
+    updateBoardData(newCardsMap, false);
+    setHistoryIdx(newHistoryIdx);
+  }
+
+  /**
+   * Brings forth the state of the board to the next state in history
+   *
+   * @returns
+   */
+  function redoBoardState() {
+    if (historyIdx >= boardHistory.length - 1) {
+      console.error(
+        "Redo action can't be done. There's no next board data stored"
+      );
+      return;
+    }
+
+    const newHistoryIdx = historyIdx + 1;
+    const newCardsMap = structuredClone(boardHistory[newHistoryIdx]);
+    updateBoardData(newCardsMap, false);
+    setHistoryIdx(newHistoryIdx);
+  }
+  return (
+    <div className="history-controls">
+      <button
+        className="undo icon"
+        aria-describedby="Undo board history"
+        onClick={undoBoardState}
+        disabled={historyIdx <= 0}
+      >
+        <span className="icon-img"></span>
+      </button>
+      <button
+        className="redo icon"
+        aria-describedby="Redo board history"
+        onClick={redoBoardState}
+        disabled={historyIdx >= boardHistory.length - 1}
+      >
+        <span className="icon-img"></span>
+      </button>
+    </div>
+  );
+}

--- a/src/icons/redo.svg
+++ b/src/icons/redo.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-redo-icon lucide-redo"><path d="M21 7v6h-6"/><path d="M3 17a9 9 0 0 1 9-9 9 9 0 0 1 6 2.3l3 2.7"/></svg>

--- a/src/icons/undo.svg
+++ b/src/icons/undo.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-undo-icon lucide-undo"><path d="M3 7v6h6"/><path d="M21 17a9 9 0 0 0-9-9 9 9 0 0 0-6 2.3L3 13"/></svg>

--- a/src/style/card.css
+++ b/src/style/card.css
@@ -9,6 +9,7 @@
 
 .card header {
   margin-bottom: 1rem;
+  overflow: hidden;
 }
 
 .card .title {
@@ -67,7 +68,6 @@
   margin-right: 0;
 }
 
-.card button.icon,
 .card button.icon {
   --buton-size: 1.25rem;
   width: var(--buton-size);

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -64,6 +64,41 @@ body.show-modal header {
   background-color: var(--card-bg-color);
 }
 
+.history-controls {
+  align-items: center;
+  display: flex;
+}
+
+.history-controls button:disabled {
+  visibility: hidden  ;
+}
+
+.history-controls button.icon {
+  --buton-size: 1.75rem;
+  width: var(--buton-size);
+  height: var(--buton-size);
+  border: 0;
+  padding: 0;
+  margin: 0.5rem 0.75rem;
+  display: flex;
+  background-color: inherit;
+}
+
+.history-controls button .icon-img {
+  width: 100%;
+  height: 100%;
+  mask-size: 100%;
+  mask-repeat: no-repeat;
+  background-color: var(--card-bg-color);
+}
+
+.history-controls button.undo .icon-img {
+  mask-image: url("../icons/undo.svg");
+}
+.history-controls button.redo .icon-img {
+  mask-image: url("../icons/redo.svg");
+}
+
 /* COLUMNS STYLE */
 
 .column {
@@ -74,6 +109,7 @@ body.show-modal header {
   background-color: var(--column-bg-color);
   color: var(--column-text-color);
   border-radius: 0.5rem;
+  overflow: hidden;
 }
 
 .column:first-child {

--- a/test/manual-tests.md
+++ b/test/manual-tests.md
@@ -12,10 +12,12 @@ Note: keep the dev tools console open to detect any error
 - Change of category
 - Edit the card (partial and full changes)
 - Remove the card
+- Undo 2 times and redo 2 times
 - Import a valid board data json file
 - Cards should be able to change order in the columns
 - Shouldn't import an invalid board data json file (e.g. invalid version number)
 - Should be able to export the board data as json file. Such file can be tested is used as import file.
+- Long text without spaces in the card shouldn't break the UI
 - Theme selector should work
 - Board data and theme should be persistant
 


### PR DESCRIPTION
This PR contains the following changes:
- added a state to keep a history of board states
  - maximum 10 entries of history 
- added an index state to move across the array of history
- added functionality to undo and redo (buttons at the top left)
- fix style issues found for specific cases when the UI broke