### PR TITLE
feat: add menu component [noissue]

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "vite",
+    "smoke-ui": "vite test/smoke-ui",
     "build": "vite build",
     "type-check": "tsc -b",
     "lint": "eslint .",

--- a/src/components/menu.specs.md
+++ b/src/components/menu.specs.md
@@ -1,0 +1,26 @@
+# Description
+This document describes the spefications around the behaviour, structure and basic style of the menu component.
+
+
+# Specifications
+
+## Structure & Style
+
+- The component should have an anchor element (menu button) and list of option elements (menu options).
+
+- The option elements should appear by default under the anchor, but if the screen doesn't allow it, it should should at the top of the anchor. In other words, the options should appear in a position, if possible, where the user can see them.
+
+
+## Behaviour
+
+- By default only the anchor should be visible and the options should be hidden.
+
+- Clicking over the anchor element will make the options visible and clicking again over the anchor should hide the options.
+
+- If the options list is open, clicking outside the options list will close the list.
+
+- Anchor and options should be accessible by keyboard:
+  - `Tab / Shift+Tab` should allow the user to focus on the menu anchor
+  - `Enter` on the anchor should show/hide the menu options. The first option item should be focused by default when the options open.
+  - If the options are open, 'arrow' keys should allow user to navigate through the options and `Enter` key will allow user to select the focused option.
+  - If the options are open, `Escape` key should hide the options list and focus on the anchor element.

--- a/src/components/menu.tsx
+++ b/src/components/menu.tsx
@@ -1,0 +1,236 @@
+import React, { useEffect, useId, useRef, useState } from "react";
+
+interface Option {
+  key: string;
+  text: string;
+  handler: (event: React.MouseEvent) => void;
+}
+
+interface MenuProps {
+  options: Option[];
+  optionsPosition?: string;
+}
+
+export default function Menu({
+  options,
+  optionsPosition,
+  children,
+}: React.PropsWithChildren<MenuProps>) {
+  const postfixId = useId();
+  const componentRef = useRef<HTMLDivElement>(null);
+  const anchorRef = useRef<HTMLButtonElement>(null);
+  const optionsRef = useRef<HTMLMenuElement>(null);
+  const [isOpen, setIsOpen] = useState(false);
+
+  function focusFirstOption() {
+    const optionsList = optionsRef.current;
+    if (!optionsList) {
+      return;
+    }
+
+    const buttons = optionsList.querySelectorAll(".option button");
+    const firstButton = buttons[0];
+
+    if (!(firstButton instanceof HTMLElement)) {
+      return;
+    }
+
+    firstButton.focus();
+  }
+
+  function toggleIsOpen(value?: boolean) {
+    const newValue = value !== undefined ? value : !isOpen;
+
+    setIsOpen(newValue);
+  }
+
+  function handleClick(event: React.MouseEvent) {
+    const { target } = event;
+
+    if (!(target instanceof HTMLElement)) {
+      return;
+    }
+
+    const { action } = target.dataset;
+
+    switch (action) {
+      case "toggle-open":
+        toggleIsOpen();
+        break;
+      case "option-selected":
+        // option behaviour is handled outside of the component
+        toggleIsOpen(false);
+        anchorRef.current?.focus();
+        break;
+      default:
+      // nothing to do here
+    }
+  }
+
+  function focusNext() {
+    const optionsList = optionsRef.current;
+    if (!optionsList) {
+      return;
+    }
+
+    const { activeElement } = document;
+    if (!activeElement) {
+      focusFirstOption();
+      return;
+    }
+
+    const buttons = optionsList.querySelectorAll(".option button");
+    const currentFocusIdx = [...buttons].findIndex(
+      (button) => button === activeElement
+    );
+
+    const nextFocusIdx = (currentFocusIdx + 1) % buttons.length;
+
+    const nextButton = buttons[nextFocusIdx];
+    if (!(nextButton instanceof HTMLElement)) {
+      return;
+    }
+    nextButton.focus();
+  }
+
+  function focusPrevious() {
+    const optionsList = optionsRef.current;
+    if (!optionsList) {
+      return;
+    }
+
+    const { activeElement } = document;
+    if (!activeElement) {
+      focusFirstOption();
+      return;
+    }
+
+    const buttons = optionsList.querySelectorAll(".option button");
+    const currentFocusIdx = [...buttons].findIndex(
+      (button) => button === activeElement
+    );
+
+    const prevFocusIdx =
+      (currentFocusIdx - 1 + buttons.length) % buttons.length;
+
+    const prevButton = buttons[prevFocusIdx];
+    if (!(prevButton instanceof HTMLElement)) {
+      return;
+    }
+    prevButton.focus();
+  }
+
+  function handleKeyDown(event: React.KeyboardEvent) {
+    if (!isOpen) {
+      // component shouldn't handle keyboard events if it's not opened
+      return;
+    }
+
+    event.stopPropagation();
+    const { key } = event;
+
+    switch (key) {
+      // 'Enter' case is handled by the 'click' event handler
+      case "Tab":
+        // 'tab' doesn't focus element options but it will close the menu
+        // so the user can continue  navigating through the document
+        event.preventDefault();
+        toggleIsOpen(false);
+        anchorRef.current?.focus();
+        break;
+      case "Escape":
+        toggleIsOpen(false);
+        anchorRef.current?.focus();
+        break;
+      case "ArrowDown":
+        focusNext();
+        break;
+      case "ArrowUp":
+        focusPrevious();
+        break;
+      default:
+      // nothing to do here
+    }
+  }
+
+  function getBestOptionsPosition() {
+    const anchorElement = anchorRef.current;
+    if (!anchorElement) {
+      return;
+    }
+
+    const rect = anchorElement.getBoundingClientRect();
+    const spaceTop = rect.top;
+    const spaceBottom = window.innerHeight - rect.bottom;
+    if (spaceBottom < spaceTop) {
+      return "top";
+    } else {
+      return "bottom";
+    }
+  }
+
+  useEffect(() => {
+    // whenever the menu opens, it should focus in the first option
+    if (isOpen) {
+      focusFirstOption();
+    }
+
+    // handle clicks outside of the component
+    addEventListener("click", (event: PointerEvent) => {
+      const { target } = event;
+
+      if (!(target instanceof HTMLElement) || !componentRef.current) {
+        return;
+      }
+
+      const closestComponentElement = target.closest(".menu-component");
+
+      if (isOpen && componentRef.current !== closestComponentElement) {
+        toggleIsOpen(false);
+      }
+    });
+  }, [isOpen]);
+
+  return (
+    <div
+      className="menu-component"
+      data-options-position={optionsPosition || getBestOptionsPosition()}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      ref={componentRef}
+    >
+      <button
+        id={"anchor" + postfixId}
+        className="anchor"
+        data-action="toggle-open"
+        ref={anchorRef}
+        aria-haspopup={true}
+        aria-controls={"menu" + postfixId}
+      >
+        {children}
+      </button>
+      <div className="options container">
+        <menu
+          hidden={!isOpen}
+          id={"menu" + postfixId}
+          className="options list"
+          ref={optionsRef}
+          aria-labelledby={"anchor" + postfixId}
+        >
+          {options.map(({ key, text, handler }) => (
+            <li key={key} className="option" role="presentation">
+              <button
+                data-key={key}
+                onClick={handler}
+                data-action="option-selected"
+                role="menuitem"
+              >
+                {text}
+              </button>
+            </li>
+          ))}
+        </menu>
+      </div>
+    </div>
+  );
+}

--- a/src/style/inbuilt-overrides.css
+++ b/src/style/inbuilt-overrides.css
@@ -3,8 +3,9 @@ input[type="file"] {
   padding: 0.3rem;
 }
 
-button:hover {
-  opacity: 0.75;
+button:hover,
+button:focus {
+  filter: brightness(1.15);
 }
 
 select {

--- a/src/style/menu.css
+++ b/src/style/menu.css
@@ -1,0 +1,37 @@
+.menu-component {
+  display: inline-block;
+  flex-direction: column;
+}
+
+.menu-component .options.container {
+  position: relative;
+}
+
+.menu-component .options.list[hidden] {
+  display: none;  
+}
+
+.menu-component .options.list {
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  margin: 0;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: max-content;
+}
+
+.menu-component[data-options-position="top"] {
+  position: relative; 
+}
+.menu-component[data-options-position="top"] .options.container{
+  position: static;
+}
+.menu-component[data-options-position="top"] .options.list {
+  transform: translateY(-100%);
+}
+
+.menu-component .option {
+  list-style: none;
+}

--- a/test/smoke-ui/index.html
+++ b/test/smoke-ui/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Smoke tests for UI components</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main id="root"></main>
+  <script type="module" src="main.tsx"></script>
+</body>
+</html>

--- a/test/smoke-ui/main.tsx
+++ b/test/smoke-ui/main.tsx
@@ -1,0 +1,103 @@
+import { createRoot } from "react-dom/client";
+import Menu from "../../src/components/menu";
+
+function print(text: string, target: EventTarget) {
+  if (!(target instanceof HTMLElement)) {
+    console.error("can't print, no target found");
+    return;
+  }
+
+  const printContainer = target.closest("[data-print-id]");
+  if(!(printContainer instanceof HTMLElement)) {
+    console.error("can't print, no print container found");
+    return;
+  }
+
+  const {printId} = printContainer.dataset
+  if(!printId) {
+    console.error("no print Id found")
+    return;
+  }
+  
+  const outputElement = document.getElementById(printId);
+  if (!outputElement) {
+    console.error("couldn't find the output element");
+    return;
+  }
+
+  outputElement.textContent = text;
+}
+
+function initialize() {
+  const rootContainer = document.getElementById("root");
+  if (!rootContainer) {
+    console.error("No root container found");
+    return;
+  }
+
+  const root = createRoot(rootContainer);
+  root.render(
+    <>
+      <header>
+        <h1>Smoke tests page for UI components</h1>
+      </header>
+      <section data-print-id="output-menu-default">
+        <h3>Menu component (default)</h3>
+        <p>
+          Output: <span className="output" id="output-menu-default"></span>
+        </p>
+        <Menu
+          options={[
+            {
+              key: "option-1",
+              text: "option 1",
+              handler: ({ target }) => print("clicked option 1", target),
+            },
+            {
+              key: "option-2",
+              text: "option 2",
+              handler: ({ target }) => print("clicked option 2", target),
+            },
+            {
+              key: "option-3",
+              text: "option 3",
+              handler: ({ target }) => print("clicked option 3", target),
+            },
+          ]}
+        >
+          Menu
+        </Menu>
+      </section>
+      <section data-print-id="output-menu-top">
+        <h3>Menu component (options at the top)</h3>
+        <p>
+          Output: <span className="output" id="output-menu-top"></span>
+        </p>
+        <Menu
+          options={[
+            {
+              key: "option-1",
+              text: "option 1",
+              handler: ({ target }) => print("clicked option 1", target),
+            },
+            {
+              key: "option-2",
+              text: "option 2",
+              handler: ({ target }) => print("clicked option 2", target),
+            },
+            {
+              key: "option-3",
+              text: "option 3",
+              handler: ({ target }) => print("clicked option 3", target),
+            },
+          ]}
+          optionsPosition="top"
+        >
+          Menu
+        </Menu>
+      </section>
+    </>
+  );
+}
+
+initialize();

--- a/test/smoke-ui/style.css
+++ b/test/smoke-ui/style.css
@@ -1,0 +1,13 @@
+@import url("../../src/style/themes.css");
+@import url("../../src/style/inbuilt-overrides.css");
+@import url("../../src/style/menu.css");
+
+header {
+  text-align: center;
+}
+
+section  {
+  display: inline-block;
+  margin: 0 1rem;
+  border: 1px solid green;
+}

--- a/test/smoke-ui/vite.config.ts
+++ b/test/smoke-ui/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  base: "/smoke-ui",
+  root: "./",
+  build: {
+    outDir: "./dist",
+    emptyOutDir: true,
+  },
+});


### PR DESCRIPTION
This PR contains the following changes:
- adds a new 'menu' react component that can be used in the board
- adds a playground 'smoke-ui' environment to visualize and test UI components