### PR TITLE
fix: vanished card data on edit form [noissue]

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -8,6 +8,7 @@ import type {
   CardExtendedData,
   CardsMap,
   ModalState,
+  ModalStateNew,
 } from "./app.types";
 import Board from "./board";
 import ExportSection from "./exportSection";
@@ -89,8 +90,8 @@ export default function App({
   initialCards,
   handleThemeChange,
 }: AppProps) {
-  const intialModalState: ModalState = { type: "new" };
-  const [modalState, setModalState] = useState(intialModalState);
+  const intialModalState: ModalStateNew = { type: "new" };
+  const [modalState, setModalState] = useState<ModalState>(intialModalState);
 
   const initialCardsMap = toCardsMap(initialCards, initialCategories);
   const [cardsMap, setCardsMap] = useState(initialCardsMap);
@@ -275,7 +276,8 @@ export default function App({
         handlers={{ deleteCard, updateCard, setModalState }}
       />
       <CardModal
-        {...{ modalState, cardsMap, boardCategories }}
+        key={modalState.type === "edit" ? modalState.cardToEdit.id : ""}
+        {...{ modalState, boardCategories }}
         handlers={{ addCard, updateCard }}
       />
       <footer>

--- a/src/components/app.types.ts
+++ b/src/components/app.types.ts
@@ -36,11 +36,21 @@ export interface CardExtendedData extends CardBaseData {
 export type CardsMap = Map<number, CardExtendedData[]>;
 
 /**
- * The state of the modal. Valid typesare:
- * - {type: "new"} -- for adding a new card
- * - {type: "edit", cardId: [string]} -- for editing an existing ca
+ * Modal used to add a new card.
  */
-export interface ModalState {
-  type: string;
-  cardId?: string;
+export interface ModalStateNew {
+  type: "new";
 }
+
+/**
+ * Modal used to edit a card.
+ */
+interface ModalStateEdit {
+  type: "edit";
+  cardToEdit: CardExtendedData;
+}
+
+/**
+ * The modal state: type and data associated to it.
+ */
+export type ModalState = ModalStateNew | ModalStateEdit;

--- a/src/components/card.tsx
+++ b/src/components/card.tsx
@@ -21,7 +21,7 @@ export default function Card({
   const { deleteCard, updateCard, setModalState } = handlers;
 
   function handleEdit() {
-    setModalState({ type: "edit", cardId: id });
+    setModalState({ type: "edit", cardToEdit: cardData });
     document.body.classList.toggle("show-modal", true);
   }
 
@@ -29,15 +29,8 @@ export default function Card({
     deleteCard(id);
   }
 
-  function handleCategoryChange(event: React.ChangeEvent) {
-    const selectElement = event.target;
-
-    if (!(selectElement instanceof HTMLSelectElement)) {
-      console.error("Event target is not a Select element");
-      return;
-    }
-
-    const newCategoryIdx = Number(selectElement.value);
+  function handleCategoryChange(newValue: string) {
+    const newCategoryIdx = Number(newValue);
 
     updateCard({
       id,
@@ -94,8 +87,8 @@ export default function Card({
       <footer>
         <CategorySelector
           categories={boardCategories}
-          defaultSelected={categoryIdx.toString()}
-          handleChange={handleCategoryChange}
+          defaultValue={categoryIdx.toString()}
+          onChange={handleCategoryChange}
         />
         <div className="buttons middle container">
           <button

--- a/src/components/cardForm.tsx
+++ b/src/components/cardForm.tsx
@@ -1,0 +1,63 @@
+import CategorySelector from "./categorySelector";
+
+const cardFormId = "modal-card-form";
+
+export interface CardFormData {
+  title: string;
+  description: string;
+  categorySelected: string;
+}
+
+interface CardFormProps {
+  formData: CardFormData;
+  onSubmit: (event: React.FormEvent) => void;
+  onChange: (newFormData: CardFormData) => void;
+  boardCategories: string[];
+}
+
+export default function CardForm({
+  formData,
+  onSubmit,
+  onChange,
+  boardCategories,
+}: CardFormProps) {
+  return (
+    <form
+      name="modal-card-form"
+      target="_self"
+      id={cardFormId}
+      onSubmit={onSubmit}
+    >
+      <label htmlFor="modal-card-title">Title: </label>
+      <input
+        type="text"
+        name="title"
+        id="modal-card-title"
+        required
+        value={formData.title}
+        onChange={({ target }) => {
+          onChange({ ...formData, title: target.value });
+        }}
+      />
+
+      <label htmlFor="modal-card-description">Description: </label>
+      <textarea
+        name="description"
+        id="modal-card-description"
+        value={formData.description}
+        onChange={({ target }) => {
+          onChange({ ...formData, description: target.value });
+        }}
+      ></textarea>
+
+      <label htmlFor="modal-card-category">Category: </label>
+      <CategorySelector
+        categories={boardCategories}
+        defaultValue={formData.categorySelected}
+        onChange={(newValue) => {
+          onChange({ ...formData, categorySelected: newValue });
+        }}
+      />
+    </form>
+  );
+}

--- a/src/components/cardModal.tsx
+++ b/src/components/cardModal.tsx
@@ -1,15 +1,18 @@
-import { toCardList } from "./app";
-import type {
-  CardBaseData,
-  CardExtendedData,
-  CardsMap,
-  ModalState,
-} from "./app.types";
-import CategorySelector from "./categorySelector";
+import { useState } from "react";
+import type { CardBaseData, CardExtendedData, ModalState } from "./app.types";
+import CardForm, { type CardFormData } from "./cardForm";
+
+const modalTitle = new Map([
+  ["new", "New card"],
+  ["edit", "Edit card"],
+]);
+const submitButtonText = new Map([
+  ["new", "add card"],
+  ["edit", "save card"],
+]);
 
 interface CardModalProps {
   modalState: ModalState;
-  cardsMap: CardsMap;
   boardCategories: string[];
   handlers: {
     addCard: (cardData: CardBaseData) => void;
@@ -19,185 +22,85 @@ interface CardModalProps {
 
 export default function CardModal({
   modalState,
-  cardsMap,
-  boardCategories,
   handlers,
+  boardCategories,
 }: CardModalProps) {
   const { addCard, updateCard } = handlers;
 
-  const modalType = modalState.type;
-  const modalTitle = new Map([
-    ["new", "New card"],
-    ["edit", "Edit card"],
-  ]);
-  const submitButtonText = new Map([
-    ["new", "add card"],
-    ["edit", "save card"],
-  ]);
-  const cardFormId = "modal-card-form";
-  const selectCategoryId = "modal-card-category";
-
-  let prefilledData = {
+  const initialFormData: CardFormData = {
     title: "",
     description: "",
-    categoryIdx: 0,
-    orderInCategory: 0,
+    categorySelected: "",
   };
 
   if (modalState.type === "edit") {
-    const cardList = toCardList(cardsMap);
-    const cardToEdit = cardList.find((card) => card.id === modalState.cardId);
-
-    if (!cardToEdit) {
-      throw new Error("No card to edit was found with the given Id");
-    }
-
-    prefilledData = {
-      categoryIdx: cardToEdit.categoryIdx,
-      title: cardToEdit.title,
-      description: cardToEdit.description,
-      orderInCategory: cardToEdit.orderInCategory,
-    };
-
-    // patch: 'select' components don't render again
-    // when the prop value used for defaultValue changes
-    const selectElement = document.getElementById(selectCategoryId);
-    if (selectElement instanceof HTMLSelectElement) {
-      selectElement.value = prefilledData.categoryIdx.toString();
-    }
+    const { cardToEdit } = modalState;
+    initialFormData.title = cardToEdit.title;
+    initialFormData.description = cardToEdit.description;
+    initialFormData.categorySelected = cardToEdit.categoryIdx.toString();
   }
 
-  function clearForm() {
-    const form = document.getElementById(cardFormId);
+  const [formData, setFormData] = useState(initialFormData);
 
-    if (!(form instanceof HTMLFormElement)) {
-      console.error("The target form to clear is not a Form element ");
-      return;
-    }
-
-    form.reset();
+  function clearFormData() {
+    setFormData({ ...initialFormData });
   }
 
-  function handleSubmitButtonClick() {
-    const form = document.getElementById(cardFormId);
-
-    if (!(form instanceof HTMLFormElement)) {
-      console.error("The target form to submit is not a Form element ");
-      return;
-    }
-
-    form.requestSubmit();
-  }
-
-  function handleCancelButtonClick() {
+  function handleClose() {
     document.body.classList.toggle("show-modal", false);
-    clearForm();
+    clearFormData();
   }
 
-  function handleSubmit(event: React.FormEvent) {
-    event.preventDefault();
-
-    const formElement = event.target;
-
-    if (!(formElement instanceof HTMLFormElement)) {
-      console.error("No form element found to submit its data");
-      return;
-    }
-
-    const formData = new FormData(formElement);
-    const [formTitle, formDescription, formCategoryIdx] = [
-      "title",
-      "description",
-      "categoryIdx",
-    ].map((fieldName) => formData.get(fieldName));
-
-    if (
-      formTitle === null ||
-      formDescription === null ||
-      formCategoryIdx === null
-    ) {
-      console.error("Couldn't get the data required to submit the form");
-      document.body.classList.toggle("show-modal", false);
-      clearForm();
-      return;
-    }
-
-    const cardData = {
-      title: formTitle.toString(),
-      description: formDescription.toString(),
-      categoryIdx: Number(formCategoryIdx),
-    };
-
-    try {
-      if (modalType === "new") {
-        addCard(cardData);
-      } else if (modalType === "edit") {
-        if (!modalState.cardId) {
-          throw new Error("No Id found in the card to edit");
-        }
-
-        updateCard({
-          id: modalState.cardId,
-          title: cardData.title,
-          description: cardData.description,
-          categoryIdx: cardData.categoryIdx,
-          orderInCategory: prefilledData.orderInCategory,
-        });
-      } else {
-        throw new Error("Card modal type not recognized");
-      }
-    } catch (error) {
-      console.error(error);
+  function handleSubmit() {
+    switch (modalState.type) {
+      case "new":
+        const cardToAdd = {
+          title: formData.title,
+          description: formData.description,
+          categoryIdx: Number(formData.categorySelected),
+        };
+        addCard(cardToAdd);
+        break;
+      case "edit":
+        const cardToUpdate = {
+          id: modalState.cardToEdit.id,
+          title: formData.title,
+          description: formData.description,
+          categoryIdx: Number(formData.categorySelected),
+          orderInCategory: modalState.cardToEdit.orderInCategory,
+        };
+        updateCard(cardToUpdate);
+        break;
+      default:
+        console.error("Card modal type not recognized");
     }
 
     document.body.classList.toggle("show-modal", false);
-    clearForm();
+    clearFormData();
+  }
+
+  function handleChange(newFormData: CardFormData) {
+    setFormData({ ...newFormData });
   }
 
   return (
     <aside className="modal">
       <section className="form-container">
-        <h2 className="title">{modalTitle.get(modalType) || ""}</h2>
+        <h2 className="title">{modalTitle.get(modalState.type) || ""}</h2>
 
-        <form
-          name="modal-card-form"
-          target="_self"
-          id={cardFormId}
+        <CardForm
+          formData={formData}
           onSubmit={handleSubmit}
-        >
-          <label htmlFor="modal-card-title">Title: </label>
-          <input
-            type="text"
-            name="title"
-            id="modal-card-title"
-            required
-            defaultValue={prefilledData.title}
-          />
-
-          <label htmlFor="modal-card-description">Description: </label>
-          <textarea
-            name="description"
-            id="modal-card-description"
-            defaultValue={prefilledData.description}
-          ></textarea>
-
-          <label htmlFor="modal-card-category">Category: </label>
-          <CategorySelector
-            id={selectCategoryId}
-            categories={boardCategories}
-            defaultSelected={prefilledData.categoryIdx.toString()}
-          />
-        </form>
+          onChange={handleChange}
+          boardCategories={boardCategories}
+        />
 
         <footer>
-          <button
-            id="cancel-modal-card-button"
-            onClick={handleCancelButtonClick}
-          >
+          <button id="cancel-modal-card-button" onClick={handleClose}>
             cancel
           </button>
-          <button id="submit-card-button" onClick={handleSubmitButtonClick}>
-            {submitButtonText.get(modalType) || ""}
+          <button id="submit-card-button" onClick={handleSubmit}>
+            {submitButtonText.get(modalState.type) || ""}
           </button>
         </footer>
       </section>

--- a/src/components/categorySelector.tsx
+++ b/src/components/categorySelector.tsx
@@ -1,31 +1,29 @@
-interface CategorySelectorProps {
-  id?: string;
-  categories: string[];
-  defaultSelected: string;
-  handleChange?: React.ChangeEventHandler;
-}
+import { useState } from "react";
 
-/**
- * A default handler for the on change event
- */
-function defaultHandleChange() {
-  // TBD the default behaviour of the handler
-  // or if we need a default behaviour at all
+interface CategorySelectorProps {
+  categories: string[];
+  defaultValue?: string;
+  onChange?: (newValue: string) => void;
 }
 
 export default function CategorySelector({
-  id = "",
   categories,
-  defaultSelected,
-  handleChange = defaultHandleChange,
+  defaultValue,
+  onChange,
 }: CategorySelectorProps) {
+  const [selected, setSelected] = useState(defaultValue);
+
+  function handleChange(event: React.ChangeEvent<HTMLSelectElement>) {
+    const { target } = event;
+    setSelected(target.value);
+
+    if (onChange) {
+      onChange(target.value);
+    }
+  }
+
   return (
-    <select
-      name="categoryIdx"
-      id={id}
-      defaultValue={defaultSelected}
-      onChange={handleChange}
-    >
+    <select name="categoryIdx" value={selected} onChange={handleChange}>
       {categories.map((category, index) => (
         <option value={index} key={index}>
           {category}

--- a/src/components/newCardButton.tsx
+++ b/src/components/newCardButton.tsx
@@ -1,5 +1,7 @@
+import type { ModalState } from "./app.types";
+
 interface NewCardButtonProps {
-  setModalState: (value: React.SetStateAction<{ type: string }>) => void;
+  setModalState: (value: React.SetStateAction<ModalState>) => void;
 }
 
 export default function NewCardButton({ setModalState }: NewCardButtonProps) {


### PR DESCRIPTION
This PR contains the following changes:
- Refactor cardModal
    - added a key attribute to identify when the modal should render again due to different type of props received
    -  simplify logic and make it more reactive
    - moved the card form logic to its own component
- Refactor categorySelector
    - control its selected element by a state variable  
    - provides also an external handler for value change