### PR TITLE
feat: close modal when user presses 'escape' key [#19]

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -90,8 +90,7 @@ export default function App({
   initialCards,
   handleThemeChange,
 }: AppProps) {
-  const intialModalState: ModalStateNew = { type: "new" };
-  const [modalState, setModalState] = useState<ModalState>(intialModalState);
+  const [modalState, setModalState] = useState<ModalState>(null);
 
   const initialCardsMap = toCardsMap(initialCards, initialCategories);
   const [cardsMap, setCardsMap] = useState(initialCardsMap);
@@ -275,11 +274,18 @@ export default function App({
         {...{ cardsMap, boardCategories }}
         handlers={{ deleteCard, updateCard, setModalState }}
       />
-      <CardModal
-        key={modalState.type === "edit" ? modalState.cardToEdit.id : ""}
-        {...{ modalState, boardCategories }}
-        handlers={{ addCard, updateCard }}
-      />
+      {modalState && (
+        <CardModal
+          key={
+            modalState.type === "edit"
+              ? modalState.cardToEdit.id
+              : modalState.type
+          }
+          {...{ modalState, boardCategories }}
+          handlers={{ addCard, updateCard }}
+          onClose={() => setModalState(null)}
+        />
+      )}
       <footer>
         <ImportSection
           {...{

--- a/src/components/app.types.ts
+++ b/src/components/app.types.ts
@@ -53,4 +53,4 @@ interface ModalStateEdit {
 /**
  * The modal state: type and data associated to it.
  */
-export type ModalState = ModalStateNew | ModalStateEdit;
+export type ModalState = ModalStateNew | ModalStateEdit | null;

--- a/src/components/cardForm.tsx
+++ b/src/components/cardForm.tsx
@@ -30,6 +30,7 @@ export default function CardForm({
     >
       <label htmlFor="modal-card-title">Title: </label>
       <input
+        autoFocus={true}
         type="text"
         name="title"
         id="modal-card-title"

--- a/src/components/cardModal.tsx
+++ b/src/components/cardModal.tsx
@@ -18,14 +18,20 @@ interface CardModalProps {
     addCard: (cardData: CardBaseData) => void;
     updateCard: (cardData: CardExtendedData) => void;
   };
+  onClose: () => void;
 }
 
 export default function CardModal({
   modalState,
-  handlers,
   boardCategories,
+  handlers,
+  onClose,
 }: CardModalProps) {
   const { addCard, updateCard } = handlers;
+
+  if (!modalState) {
+    return;
+  }
 
   const initialFormData: CardFormData = {
     title: "",
@@ -49,9 +55,14 @@ export default function CardModal({
   function handleClose() {
     document.body.classList.toggle("show-modal", false);
     clearFormData();
+    onClose();
   }
 
   function handleSubmit() {
+    if (!modalState) {
+      return;
+    }
+
     switch (modalState.type) {
       case "new":
         const cardToAdd = {
@@ -75,16 +86,27 @@ export default function CardModal({
         console.error("Card modal type not recognized");
     }
 
-    document.body.classList.toggle("show-modal", false);
-    clearFormData();
+    handleClose();
   }
 
   function handleChange(newFormData: CardFormData) {
     setFormData({ ...newFormData });
   }
 
+  function handleKeyDown(event: React.KeyboardEvent) {
+    const { key } = event;
+
+    switch (key) {
+      case "Escape":
+        handleClose();
+        break;
+      default:
+      // nothing to do here
+    }
+  }
+
   return (
-    <aside className="modal">
+    <aside className="modal" onKeyDown={handleKeyDown}>
       <section className="form-container">
         <h2 className="title">{modalTitle.get(modalState.type) || ""}</h2>
 


### PR DESCRIPTION
This PR allows users to close modal when they press the 'escape' key and the focused element was an a modal element that could trigger key down events.

In other words this will allow to close the event in the following:
- Just after opening a modal. As the focused element is a text input element.
- While changing on input elements or buttons in the modal

It won't allow to close the modal, if the user clicks outside of input elements, select elements or buttons. As the key event is not happening inside the module but rather in the document body.