### PR TITLE
fix: remove column title capitalization [noissue]

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -268,7 +268,7 @@ export default function App({
    */
   function renameColumn(columnId: number, newName: string) {
     const newCategories = [...boardCategories];
-    newCategories[columnId] = newName.trim().toLowerCase();
+    newCategories[columnId] = newName.trim();
     setBoardCategories(newCategories);
 
     const boardData = storage.board.get();

--- a/src/defaultSettings.ts
+++ b/src/defaultSettings.ts
@@ -15,7 +15,7 @@ export const defaultTheme = themes[1];
  */
 export const defaultBoardData: BoardData = {
   version: "0.2",
-  categories: ["backlog", "todo", "today", "done"],
+  categories: ["Backlog", "Todo", "Today", "Done"],
   entries: [
     {
       orderInCategory: 0,

--- a/src/style/column.css
+++ b/src/style/column.css
@@ -37,7 +37,6 @@
   width: 50%;
   flex: 1 1 auto;
   font-size: 1.5rem;
-  text-transform: capitalize;
   text-align: center;
   margin: 0 0.5rem;
   overflow: hidden;


### PR DESCRIPTION
This PR contains the following:
- remove capitalization in the style of the column title
- remove the automatic lower case transformation to the title of a column when changed
- adjust the initial column names on first run for the app