### PR TITLE
refactor: create Categories context provider [noissue]

### DIFF
--- a/src/components/board.tsx
+++ b/src/components/board.tsx
@@ -1,28 +1,25 @@
+import { useContext } from "react";
 import type { CardExtendedData, CardsMap, ModalState } from "./app.types";
 import Column from "./column";
+import { CategoriesContext } from "./categoriesContext";
 
 interface BoardProps {
   cardsMap: CardsMap;
-  boardCategories: string[];
   handlers: {
     deleteCard: (id: string) => void;
     updateCard: (cardData: CardExtendedData) => void;
-    renameColumn: (columnId: number, newName: string) => void;
     setModalState: React.Dispatch<React.SetStateAction<ModalState>>;
   };
 }
 
-export default function Board({
-  cardsMap,
-  boardCategories,
-  handlers,
-}: BoardProps) {
-  const { deleteCard, updateCard, renameColumn, setModalState } =
-    handlers;
+export default function Board({ cardsMap, handlers }: BoardProps) {
+  const { deleteCard, updateCard, setModalState } = handlers;
+
+  const categories = useContext(CategoriesContext);
 
   return (
     <section id="board">
-      {boardCategories.map((category, index) => {
+      {categories.map((category, index) => {
         const cardsInCategory = cardsMap.get(index) || [];
 
         return (
@@ -31,11 +28,9 @@ export default function Board({
             columnId={index}
             title={category}
             cards={cardsInCategory}
-            boardCategories={boardCategories}
             handlers={{
               deleteCard,
               updateCard,
-              renameColumn,
               setModalState,
             }}
           />

--- a/src/components/card.tsx
+++ b/src/components/card.tsx
@@ -1,10 +1,11 @@
+import { useContext } from "react";
 import type { CardExtendedData, ModalState } from "./app.types";
 import CategorySelector from "./categorySelector";
 import RichText from "./richText";
+import { CategoriesContext } from "./categoriesContext";
 
 interface CardProp {
   cardData: CardExtendedData;
-  boardCategories: string[];
   handlers: {
     deleteCard: (id: string) => void;
     updateCard: (cardData: CardExtendedData) => void;
@@ -12,13 +13,11 @@ interface CardProp {
   };
 }
 
-export default function Card({
-  cardData,
-  boardCategories,
-  handlers,
-}: CardProp) {
+export default function Card({ cardData, handlers }: CardProp) {
   const { id, title, description, categoryIdx, orderInCategory } = cardData;
   const { deleteCard, updateCard, setModalState } = handlers;
+
+  const boardCategories = useContext(CategoriesContext);
 
   function handleEdit(event: React.MouseEvent) {
     const { target } = event;

--- a/src/components/cardForm.tsx
+++ b/src/components/cardForm.tsx
@@ -1,4 +1,6 @@
+import { useContext } from "react";
 import CategorySelector from "./categorySelector";
+import { CategoriesContext } from "./categoriesContext";
 
 const cardFormId = "modal-card-form";
 
@@ -12,15 +14,15 @@ interface CardFormProps {
   formData: CardFormData;
   onSubmit: (event: React.FormEvent) => void;
   onChange: (newFormData: CardFormData) => void;
-  boardCategories: string[];
 }
 
 export default function CardForm({
   formData,
   onSubmit,
   onChange,
-  boardCategories,
 }: CardFormProps) {
+  const boardCategories = useContext(CategoriesContext);
+
   return (
     <form
       name="modal-card-form"

--- a/src/components/cardModal.tsx
+++ b/src/components/cardModal.tsx
@@ -13,7 +13,6 @@ const submitButtonText = new Map([
 
 interface CardModalProps {
   modalState: ModalState;
-  boardCategories: string[];
   handlers: {
     addCard: (cardData: CardBaseData) => void;
     updateCard: (cardData: CardExtendedData) => void;
@@ -23,7 +22,6 @@ interface CardModalProps {
 
 export default function CardModal({
   modalState,
-  boardCategories,
   handlers,
   onClose,
 }: CardModalProps) {
@@ -120,7 +118,6 @@ export default function CardModal({
           formData={formData}
           onSubmit={handleSubmit}
           onChange={handleChange}
-          boardCategories={boardCategories}
         />
 
         <footer>

--- a/src/components/categoriesContext.tsx
+++ b/src/components/categoriesContext.tsx
@@ -1,0 +1,65 @@
+import { createContext, useEffect, useReducer } from "react";
+import type { Action } from "./categoriesContext.types";
+import storage from "../storage";
+
+export const CategoriesContext = createContext<string[]>([]);
+export const CategoriesDispatchContext = createContext<
+  React.ActionDispatch<[action: Action]>
+>(() => {});
+
+interface CategoriesProviderProps {
+  initialCategories: string[];
+}
+
+export function CategoriesProvider({
+  initialCategories,
+  children,
+}: React.PropsWithChildren<CategoriesProviderProps>) {
+  const [categories, dispatch] = useReducer(
+    categoriesReducer,
+    initialCategories
+  );
+
+  useEffect(() => {
+    const boardData = storage.board.get();
+
+    if (!boardData) {
+      console.error("[boardData.sync] No local stored board data found");
+      return;
+    }
+
+    boardData.categories = [...categories];
+    storage.board.set(boardData);
+  }, [categories]);
+
+  return (
+    <CategoriesContext value={categories}>
+      <CategoriesDispatchContext value={dispatch}>
+        {children}
+      </CategoriesDispatchContext>
+    </CategoriesContext>
+  );
+}
+
+/**
+ * Handles actions on board categories
+ *
+ * @param categories The current list of categories
+ * @param action The action to execute
+ * @returns The new categories after the action executed
+ */
+function categoriesReducer(categories: string[], action: Action): string[] {
+  switch (action.type) {
+    case "set": {
+      return [...action.categories];
+    }
+    case "rename": {
+      const newCategories = [...categories];
+      newCategories[action.id] = action.value.trim();
+      return newCategories;
+    }
+    default: {
+      return categories;
+    }
+  }
+}

--- a/src/components/categoriesContext.types.tsx
+++ b/src/components/categoriesContext.types.tsx
@@ -1,0 +1,27 @@
+/**
+ * Categories dispatch action to set a new list of categories
+ */
+interface SetAction {
+  type: "set";
+  /**
+   * The new categories to set
+   */
+  categories: string[];
+}
+
+/**
+ * Categories dispatch action to rename a category
+ */
+interface RenameAction {
+  type: "rename";
+  /**
+   * The Id of the category to rename
+   */
+  id: number;
+  /**
+   * The new name for the category
+   */
+  value: string;
+}
+
+export type Action = SetAction | RenameAction;

--- a/src/components/column.tsx
+++ b/src/components/column.tsx
@@ -1,18 +1,17 @@
-import { useRef, useState } from "react";
+import { useContext, useRef, useState } from "react";
 import type { CardExtendedData, ModalState } from "./app.types";
 import Card from "./card";
 import Menu from "./menu";
 import TitleEditForm from "./titleEditForm";
+import { CategoriesDispatchContext } from "./categoriesContext";
 
 interface ColumnProps {
   columnId: number;
   title: string;
   cards: CardExtendedData[];
-  boardCategories: string[];
   handlers: {
     deleteCard: (id: string) => void;
     updateCard: (cardData: CardExtendedData) => void;
-    renameColumn: (columnId: number, newName: string) => void;
     setModalState: React.Dispatch<React.SetStateAction<ModalState>>;
   };
 }
@@ -21,13 +20,14 @@ export default function Column({
   columnId,
   title,
   cards,
-  boardCategories,
   handlers,
 }: ColumnProps) {
-  const { deleteCard, updateCard, renameColumn, setModalState } = handlers;
+  const { deleteCard, updateCard, setModalState } = handlers;
 
   const [isTitleEdit, setIsTitleEdit] = useState(false);
   const columnRef = useRef<HTMLElement>(null);
+
+  const categoriesDispatch = useContext(CategoriesDispatchContext);
 
   function handleMenuClick(event: React.MouseEvent) {
     const { target } = event;
@@ -72,7 +72,7 @@ export default function Column({
           <TitleEditForm
             defaultValue={title}
             handleSubmit={(value) => {
-              renameColumn(columnId, value);
+              categoriesDispatch({ type: "rename", id: columnId, value });
               setIsTitleEdit(false);
             }}
             handleCancel={() => {
@@ -108,7 +108,6 @@ export default function Column({
             <Card
               key={card.id}
               cardData={card}
-              boardCategories={boardCategories}
               handlers={{ deleteCard, updateCard, setModalState }}
             />
           </li>

--- a/src/components/importSection.tsx
+++ b/src/components/importSection.tsx
@@ -1,9 +1,10 @@
-import { useState } from "react";
+import { useContext, useState } from "react";
 
 import type { CardsMap } from "./app.types";
 import storage from "../storage";
 import { getRandomId } from "../utilities";
 import { toCardsMap } from "./app";
+import { CategoriesDispatchContext } from "./categoriesContext";
 
 const messageClassNames = {
   none: "",
@@ -12,18 +13,16 @@ const messageClassNames = {
 };
 
 interface ImportSectionProps {
-  setBoardCategories: (categories: string[]) => void;
   updateBoardData: (cardsMap: CardsMap) => void;
 }
 
-export default function ImportSection({
-  setBoardCategories,
-  updateBoardData,
-}: ImportSectionProps) {
+export default function ImportSection({ updateBoardData }: ImportSectionProps) {
   const [isFileSelected, setIsFileSelected] = useState(false);
   const [messageClassToShow, setMessageClassToShow] = useState(
     messageClassNames.none
   );
+
+  const categoriesDispatch = useContext(CategoriesDispatchContext);
 
   function handleImportFileChange(event: React.ChangeEvent) {
     const inputFileElement = event.target as HTMLInputElement;
@@ -80,7 +79,7 @@ export default function ImportSection({
     }
 
     if (isNewBoardDataStored && newBoardData) {
-      setBoardCategories(newBoardData.categories);
+      categoriesDispatch({ type: "set", categories: newBoardData.categories });
       const newCardList = newBoardData.entries.map((entry) => {
         return {
           id: getRandomId(),
@@ -90,7 +89,7 @@ export default function ImportSection({
           orderInCategory: entry.orderInCategory,
         };
       });
-      const newCardsMap = toCardsMap(newCardList, newBoardData.categories);
+      const newCardsMap = toCardsMap(newCardList);
       updateBoardData(newCardsMap);
       setMessageClassToShow(messageClassNames.success);
     } else if (oldBoardData) {


### PR DESCRIPTION
This PR contains the following:
- Created a provider context for "Categories" with state and an action reducer
- refactor the sync of storage for "categories" change as a react effect
- moved logic that is not part of the app component to the bottom of the module
- refactor `toCardsMap()` to remove the need of the 'categories' argument
- adjust components accordingly